### PR TITLE
Update master.twig: change css path for noscript

### DIFF
--- a/master.twig
+++ b/master.twig
@@ -29,9 +29,9 @@
 		<script src="{{ paths.theme }}js/skel-layers.min.js"></script>
 		<script src="{{ paths.theme }}js/init.js"></script>		
 		<noscript>
-			<link rel="stylesheet" href="css/skel.css" />
-			<link rel="stylesheet" href="css/style.css" />
-			<link rel="stylesheet" href="css/style-xlarge.css" />
+			<link rel="stylesheet" href="{{ paths.theme }}css/skel.css" />
+			<link rel="stylesheet" href="{{ paths.theme }}css/style.css" />
+			<link rel="stylesheet" href="{{ paths.theme }}css/style-xlarge.css" />
 		</noscript>
 		
 	{% endblock head %}


### PR DESCRIPTION
No css was loaded when javascript was deactivated. I changed the link to point to the theme.
(it is the first time I do that on github... it is a bit scary, I hope you don't mind. I also have some changes for solid-state... shall do the same? )
